### PR TITLE
Pick specific interface IP since a distro can have multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ user customisation of the scripts behaviour:
 
 1. `$vpn_interface_desc`
 1. `$wsl_interface_name`
+1. `$wsl_interface_id`
 1. `$config_default_wsl_guest`
 1. `$wsl_guest_list`
 1. `$state_file`
@@ -55,6 +56,20 @@ This script will accept an exact or partial match.
 
 You can determine this value by executing `Get-NetAdapter` within Powershell and looking for
 the value contained in the `Name` property/column.
+
+This script expects an exact match for this parameter.
+
+
+### $wsl_interface_id
+
+`$wsl_interface_id` is used to select the WSL2 guest Interface by matching the ID within Linux.
+
+You can determine this value by executing `ip addr` and looking for the first word
+after the Numeric ID, for example: `2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300`
+would have a network interface ID of `eth0`.  The original method of determining the
+IP address of the WSL2 host was to use the `hostname -I` command which breaks the `route add`
+command if there is more than a single IP address, such as the presence of an internal virtual
+adapter like if docker is installed within the WSL2 Linux guest.
 
 This script expects an exact match for this parameter.
 

--- a/configure-wsl-networking.ps1
+++ b/configure-wsl-networking.ps1
@@ -2,6 +2,7 @@
 
 $vpn_interface_desc = "PANGP Virtual Ethernet Adapter"
 $wsl_interface_name = "vEthernet (WSL)"
+$wsl_interface_id   = "eth0"
 
 $config_default_wsl_guest = 1 # 0: False, 1: True
 $wsl_guest_list = @()
@@ -50,9 +51,18 @@ if ($vpn_state -eq "Up") {
     echo "Determining IP Addresses of WSL2 Guest(s) ..."
     $wsl_guest_ips = [System.Collections.ArrayList]@()
     if ($config_default_wsl_guest -gt 0) {
-        $guest_ip = (wsl hostname -I)
-        $arrayId = $wsl_guest_ips.Add($guest_ip.Trim())
-        $previous_ips.Remove($guest_ip.Trim())
+        $wsl_ip_info = (wsl ip -o addr | Select-String "$wsl_interface_id\s+inet ")
+        $guest_cidr  = ($wsl_ip_info[0] -split '\s+' | Select-Object -Index 3)
+        $guest_ip    = $cidr.ToString().Split('/')[0]
+        if ([string]::IsNullOrEmpty($guest_ip))
+        {
+            echo "[DEBUG] No IP Found in default WSL2 Distribution, trying next.  (Is your default WSL2 non-interactive like Docker Desktop?)"
+        }
+        else
+        {
+            $arrayId = $wsl_guest_ips.Add($guest_ip.Trim())
+            $previous_ips.Remove($guest_ip.Trim())
+        }
     }
 
     foreach ($guest_name IN $wsl_guest_list) {


### PR DESCRIPTION
A WSL2 installation can have multiple interfaces and IP addresses.  For example, if Docker is installed inside of WSL2 (instead of as Docker Desktop due to licensing restrictions), then a second IP is provided by the `hostname -I` command that this script relies on.

Instead, I am parsing out the IP address based on the output of `ip -o addr`.  This DOES require the user to specify their interface ID if it's not `eth0`.